### PR TITLE
Fix coverage report from including tests

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -3,6 +3,8 @@ branch = True
 source = core
 parallel = True
 concurrency = thread
+omit =
+    tests/*
 
 [report]
 omit =

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,4 @@
 # pytest.ini
 [pytest]
 pythonpath = .
+addopts = --cov=core


### PR DESCRIPTION
## Summary
- update coverage configuration to omit test files
- set pytest to always measure coverage on the core package

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6869b977c9fc8329b3ee45adb6a9c5ee