### PR TITLE
Add env patches in CLI and integration tests

### DIFF
--- a/tests/integration/test_main_flow.py
+++ b/tests/integration/test_main_flow.py
@@ -1,5 +1,8 @@
+import os
 from unittest.mock import patch, MagicMock
 from core.import_udl_to_nominal import main
+
+@patch.dict(os.environ, {"basicAuth": "x", "nom_key": "y", "n2yo_key": "z"}, clear=True)
 
 @patch("core.import_udl_to_nominal.requests.get")
 @patch("core.import_udl_to_nominal.NominalClient.from_token")

--- a/tests/unit/test_main_cli.py
+++ b/tests/unit/test_main_cli.py
@@ -23,6 +23,8 @@ def test_main_help_flag_runs():
 # Test for Secure Messaging API exit path
 from unittest.mock import patch, MagicMock
 
+@patch.dict(os.environ, {"basicAuth": "x", "nom_key": "y", "n2yo_key": "z"}, clear=True)
+
 @patch("builtins.print")
 @patch("core.import_udl_to_nominal.sys.exit", side_effect=SystemExit)
 @patch("core.import_udl_to_nominal.input", side_effect=["12345", "2025-07-05T00:00:00.000Z", "2025-07-05T01:00:00.000Z"])


### PR DESCRIPTION
## Summary
- patch env vars in integration and CLI tests so `load_env_variables()` runs cleanly

## Testing
- `pip install -r requirements/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6869bc5870888329a98e5d873a286593