### PR TITLE
Fix label workflow

### DIFF
--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -9,6 +9,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
       - uses: actions/labeler@v5
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
+          configuration-path: .github/labeler.yml


### PR DESCRIPTION
## Summary
- checkout repo before running labeler
- specify the labeler config path

## Testing
- `actionlint .github/workflows/label.yml`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6869bc5fa2d48329aa37004dab04ecb2