### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,5 +1,8 @@
 name: "Lint"
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [main]


### PR DESCRIPTION
Potential fix for [https://github.com/tarunprakash2468/Watchtower/security/code-scanning/4](https://github.com/tarunprakash2468/Watchtower/security/code-scanning/4)

To fix the problem, add an explicit `permissions` block to the workflow. Since this workflow only performs linting tasks (reading and analyzing code), it requires minimal permissions, specifically `contents: read`. Adding this block ensures that the workflow does not inherit excessive permissions and adheres to the principle of least privilege.

The `permissions` block should be added at the root level of the workflow (e.g., just below `name: "Lint"`) to apply to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
