### PR TITLE
Implement UDL streaming to Nominal

### DIFF
--- a/tests/unit/test_main_cli.py
+++ b/tests/unit/test_main_cli.py
@@ -21,20 +21,17 @@ def test_main_help_flag_runs():
     assert result.returncode in (0, 1)  # your --help might exit(0) or exit(1)
     assert "usage" in result.stdout.lower() or "usage" in result.stderr.lower()
 
-# Test for Secure Messaging API exit path
+# Secure Messaging API triggers streaming
 
 @patch.dict(os.environ, {"basicAuth": "x", "nom_key": "y", "n2yo_key": "z"}, clear=True)
 
-@patch("builtins.print")
-@patch("core.import_udl_to_nominal.sys.exit", side_effect=SystemExit)
-@patch("core.import_udl_to_nominal.input", side_effect=["12345", "2025-07-05T00:00:00.000Z", "2025-07-05T01:00:00.000Z"])
+@patch("core.import_udl_to_nominal.stream_secure_messaging_to_nominal")
+@patch("core.import_udl_to_nominal.input", side_effect=["12345", "statevector"])
 @patch("core.import_udl_to_nominal.questionary.select")
-def test_main_secure_api_exit(mock_select: MagicMock, mock_input: MagicMock, mock_exit: MagicMock, mock_print: MagicMock):
+def test_main_secure_api_stream(mock_select: MagicMock, mock_input: MagicMock, mock_stream: MagicMock):
     mock_select.return_value.ask.return_value = "Secure Messaging API"
 
     from core.import_udl_to_nominal import main
-    with pytest.raises(SystemExit):
-        main([])
+    main([])
 
-    mock_print.assert_any_call("Secure Messaging API requires access request. Contact UDL support.")
-    mock_exit.assert_called_once_with(1)
+    mock_stream.assert_called_once()

--- a/tests/unit/test_stream_secure_messaging.py
+++ b/tests/unit/test_stream_secure_messaging.py
@@ -1,0 +1,46 @@
+from unittest.mock import MagicMock, patch
+from core import import_udl_to_nominal as mod
+
+
+def _fake_response(text=None, json_data=None, headers=None):
+    resp = MagicMock()
+    if text is not None:
+        resp.text = text
+    if json_data is not None:
+        resp.json.return_value = json_data
+    resp.headers = headers or {}
+    resp.raise_for_status.return_value = None
+    return resp
+
+
+@patch("core.import_udl_to_nominal.time.sleep")
+@patch("core.import_udl_to_nominal.requests.Session")
+def test_stream_secure_messaging(mock_session_cls, mock_sleep):
+    client = MagicMock()
+    dataset = MagicMock()
+    asset = MagicMock()
+    stream = MagicMock()
+    dataset.get_write_stream.return_value.__enter__.return_value = stream
+    client.create_dataset.return_value = dataset
+    client.create_asset.return_value = asset
+
+    session = MagicMock()
+    mock_session_cls.return_value = session
+    session.get.side_effect = [
+        _fake_response(text="5"),
+        _fake_response(json_data=[{
+            "epoch": "2025-01-01T00:00:00Z",
+            "xpos": 1,
+            "ypos": 2,
+            "zpos": 3,
+            "xvel": 4,
+            "yvel": 5,
+            "zvel": 6
+        }], headers={"KAFKA_NEXT_OFFSET": "6"})
+    ]
+
+    mod.stream_secure_messaging_to_nominal(client, "auth", "statevector", "sat", max_messages=1, sample_period=0)
+
+    dataset.get_write_stream.assert_called_once()
+    stream.enqueue.assert_any_call("pos.x", "2025-01-01T00:00:00Z", 1)
+    asset.add_dataset.assert_called_once()


### PR DESCRIPTION
## Summary
- stream UDL Secure Messaging data into Nominal
- expose `--topic` CLI flag and stream when API=Secure Messaging
- add unit test for streaming helper
- update CLI test to check streaming path

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687da085ebbc8329840b578b3fa406a7